### PR TITLE
Message stack in the agent

### DIFF
--- a/examples/behaviours-and-messages/MessageAgents.py
+++ b/examples/behaviours-and-messages/MessageAgents.py
@@ -17,6 +17,9 @@ class SenderAgent(Agent):
 		self.add_behaviour(SendMessage(self))
 
 class SendMessage(OneShotBehaviour):
+	def __init__(self, agent):
+		super().__init__(agent)
+
 	def action(self):
 		# Create a message with INFORM performative
 		message = ACLMessage(ACLMessage.INFORM)
@@ -25,9 +28,8 @@ class SendMessage(OneShotBehaviour):
 		# Adds some content
 		message.set_content('Hello! :)')
 		# Send the message to receiver
-		self.send(message)
+		self.agent.send(message)
 		display(self.agent, 'I sent a message to receiver.')
-
 
 # Receiver Agent
 class ReceiverAgent(Agent):
@@ -36,12 +38,15 @@ class ReceiverAgent(Agent):
 		self.add_behaviour(ReceiveMessage(self))
 
 class ReceiveMessage(CyclicBehaviour):
-	def action(self):
-		# Receives (reads) the message from queue
-		message = self.read()
-		# Shows the message content
-		display(self.agent, 'I received a message with the content: %s.' % message.content)
+	def __init__(self, agent):
+		super().__init__(agent)
 
+	def action(self):
+		if self.agent.has_messages():
+			# Receives (reads) the message from queue
+			message = self.agent.read()
+			# Shows the message content
+			display(self.agent, 'I received a message with the content: %s.' % message.content)
 
 if __name__ == '__main__':
 	agents = list()

--- a/examples/behaviours-and-messages/MessageAgents.py
+++ b/examples/behaviours-and-messages/MessageAgents.py
@@ -17,9 +17,6 @@ class SenderAgent(Agent):
 		self.add_behaviour(SendMessage(self))
 
 class SendMessage(OneShotBehaviour):
-	def __init__(self, agent):
-		super().__init__(agent)
-
 	def action(self):
 		# Create a message with INFORM performative
 		message = ACLMessage(ACLMessage.INFORM)
@@ -38,9 +35,6 @@ class ReceiverAgent(Agent):
 		self.add_behaviour(ReceiveMessage(self))
 
 class ReceiveMessage(CyclicBehaviour):
-	def __init__(self, agent):
-		super().__init__(agent)
-
 	def action(self):
 		if self.agent.has_messages():
 			# Receives (reads) the message from queue

--- a/examples/behaviours-and-messages/PingPongAgent.py
+++ b/examples/behaviours-and-messages/PingPongAgent.py
@@ -34,17 +34,18 @@ class PingTurn(CyclicBehaviour):
 		# behaviour, use self.read(block = False) or 
 		# self.read_timeout(timeout). These methods returns None 
 		# if don't have messages to agent. See docs to more details.
-		message = self.read()
-		if message.sender == self.agent.pong:
-			# Preparing a reply to self.receiver
-			reply = message.create_reply()
-			reply.set_content('PING')
-			display_message(self.agent, 'Turn: %s' % message.content)
-			# Wait a time before send the message
-			#(Do you want to see the results, don't you?)
-			self.wait(0.5)
-			# Sending the message
-			self.send(reply)
+		if self.agent.has_messages():
+			message = self.agent.read()
+			if message.sender == self.agent.pong:
+				# Preparing a reply to self.receiver
+				reply = message.create_reply()
+				reply.set_content('PING')
+				display_message(self.agent, 'Turn: %s' % message.content)
+				# Wait a time before send the message
+				#(Do you want to see the results, don't you?)
+				self.wait(0.5)
+				# Sending the message
+				self.send(reply)
 
 
 # ==== Pong Agent ====
@@ -59,15 +60,16 @@ class PongAgent(Agent):
 
 class PongTurn(CyclicBehaviour):
 	def action(self):
-		message = self.read()
-		if message.sender == self.agent.ping:
-			# Preparing a reply to 'ping'
-			reply = message.create_reply()
-			reply.set_content('PONG')
-			display_message(self.agent, 'Turn: %s' % message.content)
-			self.wait(0.5)
-			# Sending the reply
-			self.send(reply)
+		if self.agent.has_messages():
+			message = self.agent.read()
+			if message.sender == self.agent.ping:
+				# Preparing a reply to 'ping'
+				reply = message.create_reply()
+				reply.set_content('PONG')
+				display_message(self.agent, 'Turn: %s' % message.content)
+				self.wait(0.5)
+				# Sending the reply
+				self.send(reply)
 
 
 # ==== Starting main loop of PADE ====

--- a/examples/behaviours-and-messages/TicTacAgent_DoubleTicker.py
+++ b/examples/behaviours-and-messages/TicTacAgent_DoubleTicker.py
@@ -1,0 +1,24 @@
+from pade.behaviours.types import TickerBehaviour
+from pade.core.agent import Agent
+from pade.misc.utility import display_message, start_loop
+
+'''
+This example presents two different TickerBehaviour
+running in paralell and in an alternating way
+'''
+
+class TicTacAgent(Agent):
+	def setup(self):
+		self.add_behaviour(TicBehaviour(self, 1))
+		self.add_behaviour(TacBehaviour(self, 1))
+
+class TicBehaviour(TickerBehaviour):
+	def on_tick(self):
+		display_message(self.agent, 'Tic')
+
+class TacBehaviour(TickerBehaviour):
+	def on_tick(self):
+		display_message(self.agent, 'Tac')
+
+if __name__ == '__main__':
+	start_loop([TicTacAgent('tictac')])

--- a/pade/core/agent.py
+++ b/pade/core/agent.py
@@ -37,6 +37,7 @@ from twisted.internet import protocol, reactor
 
 from pade.core.peer import PeerProtocol
 from pade.acl.messages import ACLMessage
+from pade.acl.filters import Filter
 from pade.core.delivery import DeliverPostponedMessage
 from pade.behaviours.protocols import Behaviour
 from pade.behaviours.base import BaseBehaviour
@@ -45,6 +46,7 @@ from pade.acl.aid import AID
 from pade.scheduler.core import Scheduler, BehaviourTask
 from pade.misc.utility import display_message
 
+from collections import deque
 from pickle import dumps, loads
 import random
 
@@ -241,6 +243,8 @@ class Agent_(object):
         A dictionary with AMS information {'name': ams_IP, 'port': ams_port}
     behaviours : list
         Agent's behaviours list
+    messages : deque
+        Messages received by the agent
     debug : boollean
         if True activate the debug mode
     ILP : TYPE
@@ -271,6 +275,7 @@ class Agent_(object):
         self.ams = dict()
         self.sniffer = dict()
         self.behaviours = list()
+        self.messages = deque()
         self.system_behaviours = list()
         self.__messages = list()
         self.ILP = None
@@ -442,13 +447,33 @@ class Agent_(object):
         message : ACLMessage
             receive message 
         """
-
         if message.system_message:
             for system_behaviour in self.system_behaviours:
                 system_behaviour.execute(message)
         else:
             for behaviour in self.behaviours:
                 behaviour.execute(message)
+
+    def read(self, messageFilters=None):
+        '''
+        Get the first message from the top of the message stack (left-side of
+        the deque) with match the filters provided.
+
+        If any filter was provided, return the message from the top of stack.
+        Parameters
+        ----------
+        messageFilters : Filter
+            filter to be applied at the messages
+        '''
+        if messageFilters == None:
+            return self.messages.popleft()
+
+        for i in self.messages:
+            if messageFilters.filter(i):
+                self.messages.remove(i)
+                return i
+
+        return None
 
     def send(self, message):
         """This method calls the method self._send to sends 
@@ -776,9 +801,8 @@ class Agent(Agent_):
             _message.set_system_message(is_system_message=True)
             self.send(_message)
 
-        # Passes the received message to all behaviours
         if not self.ignore_ams or not message.system_message:
-            self.receive(message)
+            self.messages.appendleft(message)
 
     def setup(self):
         ''' This method is an alternative to initiate agents without
@@ -812,12 +836,11 @@ class Agent(Agent_):
         except ValueError:
             raise ValueError('the behaviour does not exists in scheduler.')
 
-    def receive(self, message):
-        ''' It passes the arrived message to all existing behaviours in 
-        scheduler (all behaviours in the self.scheduler.behaviours queue).
+    def has_messages(self):
+        ''' A method to returns if this behaviour has messages in its
+        received messages queue.
         '''
-        for task in self.scheduler.active_tasks:
-            task.behaviour.receive(message)
+        return len(self.messages) > 0
 
     def pause_agent(self):
         ''' This method indicates to scheduler to pause its activities.


### PR DESCRIPTION
Move the message stack from the behaviours to the agent.

The patch ported some examples to this new approach, the most important are `MessageAgents.py` and `PingPongAgent.py` to show how it works in a small examples, and `Supermarket.py` to show different CyclicBehaviours working on a unique message stack.

Currently the code for messages in behaviours was not deleted.